### PR TITLE
add qrcode to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-intl": "^6.0.8",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
-    "release-it": "^15.3.0"
+    "release-it": "^15.3.0",
+    "qrcode":"^1.5.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^3.3.0",


### PR DESCRIPTION
Fixes missing package error: 
`/strapi-plugin-qrcode-generator/strapi-server.js: Cannot find module 'qrcode'`